### PR TITLE
Add mention of 'Open positions' in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The job board of Ruby Belgium.
 1. Fork it ( https://github.com/brug-be/jobboard/fork )
 2. Create your branch (git checkout -b company-position-title)
 3. Create a file following the format `yyyymmdd_company_position_title.md`
-4. Commit your changes (git commit -am 'Open a new position at company')
-5. Push to the branch (git push origin company-position-title)
-6. Create a new Pull Request, mention on which channel you want it to be shared
+5. Edit the `README.md` file to link to your offer under `Open positions`
+5. Commit your changes (git commit -am 'Open a new position at company')
+6. Push to the branch (git push origin company-position-title)
+7. Create a new Pull Request, mention on which channel you want it to be shared


### PR DESCRIPTION
Three out of three merge requests missed updating the `Open positions` link in the `README.md`: this patch adds this step to the instructions so that this situation is avoided in the future.